### PR TITLE
Display no-diff status message

### DIFF
--- a/internal/ui/views/view.go
+++ b/internal/ui/views/view.go
@@ -98,7 +98,7 @@ func (r *Renderer) Render(state ViewState) string {
 
 	// Build the title line with right-aligned indicators
 	var titleLine string
-	if len(loadingIndicators) > 0 || state.FilterQuery != "" {
+	if len(loadingIndicators) > 0 || state.FilterQuery != "" || state.StatusMessage != "" {
 		// Calculate widths
 		logoWidth := lipgloss.Width(logo)
 


### PR DESCRIPTION
## Summary
- ensure the "No uncommitted changes" status message renders even when no loading indicators or filter are present

## Testing
- `go test ./...`
- `npm test` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68bf078ac2f48325be5c1abc9218c7ad